### PR TITLE
改进使用体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+在终端上演示《传送门》片尾曲效果的 Python 脚本程序。
+
+## 使用条件
+
+`still_alive_credit.py` 脚本使用 Python 3，以下提到的 `pip` 多数情况下对应 `pip3` 命令
+以调用 Python 3 的 `pip` 组件。
+
+Windows 下需要使用 Windows terminal，MinTTY 等支持 ANSI 终端转义序列的终端模拟器。
+
+为了播放音乐，需要用 `pip` 安装 `playsound`。`playground` 在 Linux 下依赖 
+`python-gobject` 软件包（Ubuntu 已默认安装）。在 MacOS 下还需要用 `pip` 安装 `PyObjC`。
+
+## 使用方法
+
+在当前目录下执行：
+
+```
+python3 still_alive_credit.py
+```
+
+脚本会读取 `TERM`，`COLUMNS` 和 `LINES` 环境变量来调整输出区域大小并决定是否启用终端颜色等
+特性。如果希望在一台标准 VT100 终端上演示，应该运行：
+
+```
+TERM=vt100 python3 still_alive_credit.py
+```
+
+可以使用 `--no-sound` 参数不带音乐进行演示，此时脚本只依赖 Python 标准库：
+
+```
+python3 still_alive_credit.py --no-sound
+```
+
+---
+
+A demo of the credit song 'Still Alive' of Portal 1 written in Python, running
+in text terminal.
+
+## Dependency
+
+`still_alive_credit.py` is written with Python 3. In most cases the following
+`pip` should be `pip3` command.
+
+In Windows system, you need a teminal emulator supporting ANSI escape sequences
+like Windows Terminal, MinTTY, Cmder or ConEmu。
+
+For playing music, you need install `playsound` with `pip`. In Linux `playsound`
+depends on `python-gobject` (default installed in Ubuntu). In MacOS you also need
+to use `pip` to install `PyObjC`.
+
+## Usage
+
+In current directory, execute:
+
+```
+python3 still_alive_credit.py
+```
+
+The script will read environment variable `TERM`, `COLUMNS` and `LINES` to determine
+the output area size and whether to enable features such as terminal color. If you
+want run it on a standard VT100 terminal, you should execute:
+
+```
+TERM=vt100 python3 still_alive_credit.py
+```
+
+It's able to use `--no-sound` option to run the script without playing sound. In this
+case, the script only depends on Python standard library:
+
+```
+python3 still_alive_credit.py --no-sound
+```
+
+## Linux 运行效果 / Snapshot on Linux
+
+![](still_alive_linux.jpg)
+
+## 演示视频 / demonstration video
+
+![](still_alive_informer213.jpg)
+
+<https://www.bilibili.com/video/BV1cU4y1A7ud>

--- a/still_alive_credit.py
+++ b/still_alive_credit.py
@@ -33,6 +33,7 @@ import threading
 import playsound
 import os
 import re
+import signal
 
 cursor_x = 1
 cursor_y = 1
@@ -51,6 +52,13 @@ enable_screen_buffer = not (is_vt or term == "linux")
 enable_color = not is_vt or int(is_vt[1]) >= 241
 
 is_draw_end = False
+
+def sigint_handler(sig, frame):
+    end_draw()
+    print('Interrupt by user')
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, sigint_handler)
 
 def begin_draw():
     if enable_screen_buffer:

--- a/still_alive_credit.py
+++ b/still_alive_credit.py
@@ -51,6 +51,19 @@ enable_screen_buffer = not (is_vt or term == "linux")
 # color support is after VT241
 enable_color = not is_vt or int(is_vt[1]) >= 241
 
+term_columns, term_lines = 0, 0
+if is_vt:
+    term_columns, term_lines = 80, 24
+else:
+    term_columns, term_lines = os.get_terminal_size()
+
+term_columns = int(os.getenv("COLUMNS", term_columns))
+term_lines = int(os.getenv("LINES", term_lines))
+
+if term_columns < 80 or term_lines < 24:
+    print("the terminal size should be at least 80x24")
+    sys.exit(1)
+
 is_draw_end = False
 
 def sigint_handler(sig, frame):
@@ -143,6 +156,20 @@ class lyric:
         self.interval = _interval
         self.mode = _mode
 
+
+ascii_art_width = 40
+ascii_art_height = 20
+
+credits_width = min((term_columns - 4) // 2, 56)
+credits_height = term_lines - ascii_art_height - 2
+
+lyric_width = term_columns - 4 - credits_width
+lyric_height = term_lines - 2
+
+credits_pos_x = lyric_width + 4
+
+ascii_art_x = lyric_width + 4 + (credits_width - ascii_art_width) // 2
+ascii_art_y = credits_height + 3
 
 a1 = ["              .,-:;//;:=,               ",
       "          . :H@@@MM@M#H/.,+%;,          ",
@@ -697,67 +724,31 @@ ENRICHMENT CENTER ACTIVITY!!"""
 
 
 def drawAA(x, y, ch):
-    for y0 in range(1, 21):
-        move(x, y0 + y)
-        print(ascii_art[ch][y0 - 1], end='')
+    for dy in range(ascii_art_height):
+        move(x, y + dy)
+        print(ascii_art[ch][dy], end='')
         sys.stdout.flush()
         time.sleep(0.01)
 
 
 def drawFrame():
     move(1, 1)
-    _print(' --------------------------------------  -------------------------------------- ', True)
-    _print('|                                      ||                                      |', True)
-    _print('|                                      ||                                      |', True)
-    _print('|                                      | -------------------------------------- ', True)
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print('|                                      |')
-    _print(' -------------------------------------- ', False)
+    _print(' ' + '-' * lyric_width + '  ' + '-' * credits_width + ' ')
+    for _ in range(credits_height):
+        _print('|' + ' ' * lyric_width + '||' + ' ' * credits_width + '|')
+    _print('|' + ' ' * lyric_width + '| ' + '-' * credits_width + ' ')
+    for _ in range(lyric_height - 1 - credits_height):
+        _print('|' + ' ' * lyric_width + '|')
+    _print(' ' + '-' * lyric_width + ' ', False)
+    move(2, 2)
     sys.stdout.flush()
     time.sleep(1)
 
 
 def clearLyrics():
     move(1, 2)
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
-    _print('|                                  ')
+    for _ in range(lyric_height):
+        _print('|' + ' ' * lyric_width)
     move(2, 2)
 
 
@@ -782,34 +773,42 @@ class thread_credits (threading.Thread):
         credit_x = 0
         i = 0
         length = len(credits)
-        last_credit = ""
+        last_credits = [""]
         startTime = time.time()
         for ch in credits:
             currentTime = startTime + 174.0 / length * i
             i += 1
-            if(ch == '\n'):
+            if ch == '\n':
                 credit_x = 0
-                for j in range(len(last_credit), 33):
-                    last_credit += " "
+                last_credits.append("")
+                if len(last_credits) > credits_height:
+                    last_credits = last_credits[-credits_height:]
                 print_lock.acquire()
                 if is_draw_end:
+                    print_lock.release()
                     break
-                move(44, 2, False, False)
-                print(last_credit, end='')
-                move(44 + credit_x, 3, False, False)
-                print("                                 ", end='')
+                for y in range(2, 2 + credits_height - len(last_credits)):
+                    move(credits_pos_x, y, False, False)
+                    print(' ' * credits_width, end='')
+                for k in range(len(last_credits)):
+                    y = 2 + credits_height - len(last_credits) + k
+                    move(credits_pos_x, y, False, False)
+                    print(last_credits[k], end='')
+                    print(' ' * (credits_width - len(last_credits[k])), end='')
                 move(cursor_x, cursor_y, False, False)
                 print_lock.release()
-                last_credit = ""
             else:
-                last_credit += ch
+                last_credits[-1] += ch
                 print_lock.acquire()
-                move(44 + credit_x, 3, False, False)
+                if is_draw_end:
+                    print_lock.release()
+                    break
+                move(credits_pos_x + credit_x, credits_height + 1, False, False)
                 print(ch, end='')
                 move(cursor_x, cursor_y, False, False)
                 print_lock.release()
                 credit_x += 1
-            while(time.time() < currentTime):
+            while time.time() < currentTime:
                 time.sleep(0.01)
 
 
@@ -855,7 +854,7 @@ while(lyrics[currentLyric].mode != 9):
                            interval,
                            False)
         elif(lyrics[currentLyric].mode == 2):
-            drawAA(41, 4, lyrics[currentLyric].words)
+            drawAA(ascii_art_x, ascii_art_y, lyrics[currentLyric].words)
             move(x + 2, y + 2)
         elif(lyrics[currentLyric].mode == 3):
             clearLyrics()

--- a/still_alive_credit.py
+++ b/still_alive_credit.py
@@ -31,6 +31,7 @@ import time
 import sys
 import threading
 import os
+import shutil
 import re
 import signal
 from pathlib import Path
@@ -41,7 +42,6 @@ print_lock = threading.Lock()
 
 
 term = os.getenv("TERM", "vt100")
-
 is_vt = re.search(r"vt(\d+)", term)
 
 # xterm, rxvt, konsole ...
@@ -49,7 +49,7 @@ is_vt = re.search(r"vt(\d+)", term)
 enable_screen_buffer = not (is_vt or term == "linux")
 
 # color support is after VT241
-enable_color = not is_vt or int(is_vt[1]) >= 241
+enable_color = not is_vt or int(re.search(r"\d+", is_vt.group()).group()) >= 241
 
 enable_sound = '--no-sound' not in sys.argv
 
@@ -60,7 +60,7 @@ term_columns, term_lines = 0, 0
 if is_vt:
     term_columns, term_lines = 80, 24
 else:
-    term_columns, term_lines = os.get_terminal_size()
+    term_columns, term_lines = shutil.get_terminal_size()
 
 term_columns = int(os.getenv("COLUMNS", term_columns))
 term_lines = int(os.getenv("LINES", term_lines))
@@ -85,7 +85,7 @@ def begin_draw():
         print_lock.release()
     if enable_color:
         print_lock.acquire()
-        print('\033[92;40m', end='')
+        print('\033[33;40;1m', end='')
         print_lock.release()
 
 
@@ -738,10 +738,10 @@ def drawAA(x, y, ch):
 
 def drawFrame():
     move(1, 1)
-    _print(' ' + '-' * lyric_width + '  ' + '-' * credits_width + ' ')
+    _print(' ' + '-' * lyric_width + '  ' + '-' * credits_width + ' ', not is_vt)
     for _ in range(credits_height):
-        _print('|' + ' ' * lyric_width + '||' + ' ' * credits_width + '|')
-    _print('|' + ' ' * lyric_width + '| ' + '-' * credits_width + ' ')
+        _print('|' + ' ' * lyric_width + '||' + ' ' * credits_width + '|', not is_vt)
+    _print('|' + ' ' * lyric_width + '| ' + '-' * credits_width + ' ', not is_vt)
     for _ in range(lyric_height - 1 - credits_height):
         _print('|' + ' ' * lyric_width + '|')
     _print(' ' + '-' * lyric_width + ' ', False)

--- a/still_alive_credit.py
+++ b/still_alive_credit.py
@@ -30,10 +30,10 @@
 import time
 import sys
 import threading
-import playsound
 import os
 import re
 import signal
+from pathlib import Path
 
 cursor_x = 1
 cursor_y = 1
@@ -50,6 +50,11 @@ enable_screen_buffer = not (is_vt or term == "linux")
 
 # color support is after VT241
 enable_color = not is_vt or int(is_vt[1]) >= 241
+
+enable_sound = '--no-sound' not in sys.argv
+
+if enable_sound:
+    import playsound
 
 term_columns, term_lines = 0, 0
 if is_vt:
@@ -861,7 +866,8 @@ while(lyrics[currentLyric].mode != 9):
             x = 0
             y = 0
         elif(lyrics[currentLyric].mode == 4):
-            playsound.playsound('sa1.mp3', False)
+            if enable_sound:
+                playsound.playsound(str(Path.cwd() / 'sa1.mp3'), False)
         elif(lyrics[currentLyric].mode == 5):
             th_credit = thread_credits()
             th_credit.daemon = True


### PR DESCRIPTION
- 在支持的情况下设置文本颜色为亮绿色
- 默认占满整个终端大小，可通过 TERM 环境变量改变此行为
- 允许在播放过程中用 <kbd>CTRL</kbd> + <kbd>C</kbd> 退出
- 增加 `--no-sound` 选项不播放声音
- 增加 `README.md`

在 Linux 与 MacOS 上经过测试，运行良好，但需要安装相应依赖（见 `README.md`）。

在 Windows 上测试了 MSYS2 的 mintty，CoEmu 的 CMD 和 MSYS2 配置，Windows Terminal 的 PowerShell 配置，控制台输出基本都能进行，声音播放均有不同程度 Bug：
- MSYS2 完全无法运行
  - msys 配置下 playsound 识别为 Linux 环境，但无法安装 python-gobject
  - mingw 配置下playsound 识别为 Windows，但无法引用 msvcrt；
- Windows 版 Python 需要提供 MP3 文件完整路径，否则无声；即使提供了也会在控制台打印错误信息，是 playsound 的 Bug。

清屏指令改用 `CSI 2 J`， VT100 应当支持，希望能用 Informer 213 测试一下。